### PR TITLE
Updates to Kubernetes deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ debug_*
 # .env files
 *.env
 elasticsearch_env
+aks-deployment.my.yml

--- a/deploy/aks-deployment.yml
+++ b/deploy/aks-deployment.yml
@@ -148,16 +148,19 @@ spec:
           livenessProbe:
             httpGet:
               path: /api/health
-              port: 80
+              port: 8080
             initialDelaySeconds: 90
             periodSeconds: 30
             failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /api/health
-              port: 80
+              port: 8080
             initialDelaySeconds: 30
             periodSeconds: 10
+          securityContext:
+            runAsUser: 472
+            runAsGroup: 472
       volumes:
         - name: grafana-data
           persistentVolumeClaim:
@@ -173,7 +176,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/deploy/kubernetes.md
+++ b/deploy/kubernetes.md
@@ -20,13 +20,15 @@ Dependent technology stack:
 Available [here](aks-deployment.yml).
 
 ## Deploy in Kubernetes
+
 This document describes how to deploy the application in Kubernetes.
 
 Variables used in the manifest:
- - `__GITHUB_PAT__`
- - `__GRAFANA_USERNAME__`
- - `__GRAFANA_PASSWORD__`
- - `__ORGANIZATION_SLUGS__`
+
+- `__GITHUB_PAT__`
+- `__GRAFANA_USERNAME__`
+- `__GRAFANA_PASSWORD__`
+- `__ORGANIZATION_SLUGS__`
 
 Replacement can be done using `envsubst` tool:
 
@@ -42,6 +44,7 @@ envsubst < deploy/aks-deployment.yml | kubectl apply -f -
 ### Deployment in Azure Kubernetes Service - AKS
 
 If you're using Azure Kubernetes Service - AKS:
+
 1. Enable [App Routing](https://learn.microsoft.com/en-us/azure/aks/app-routing)
 2. Update variables.
 3. Apply the manifest in your cluster.
@@ -52,3 +55,48 @@ If you're using Azure Kubernetes Service - AKS:
 2. Update Ingress
 3. Update variables.
 4. Apply the manifest in your cluster.
+
+### Troubleshooting Grafana "database is locked" Error
+
+Grafana database can lock which can cause container to fail, see [Grafana, SQLite, and database is locked](https://opsverse.io/2022/12/15/grafana-sqlite-and-database-is-locked/)
+
+Use following Job to unlock the database.
+
+```yaml
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fix-grafana-once
+spec:
+  template:
+    spec:
+      containers:
+        - name: fix-grafana
+          image: keinos/sqlite3
+          imagePullPolicy: IfNotPresent
+          command:
+          - "/bin/sh"
+          - "-c"
+          - "/usr/bin/sqlite3 /var/lib/grafana/grafana.db '.clone /var/lib/grafana/grafana.db.clone'; mv /var/lib/grafana/grafana.db.clone /var/lib/grafana/grafana.db; chmod a+w /var/lib/grafana/grafana.db"
+          volumeMounts:
+            - name: grafana-data
+              mountPath: /var/lib/grafana
+              subPath: grafana
+          securityContext:
+            runAsUser: 0
+          resources:
+            requests:
+              cpu: "0.25"
+              memory: "256Mi"
+            limits:
+              cpu: "0.5"
+              memory: "512Mi"
+      restartPolicy: Never
+      volumes:
+        - name: grafana-data
+          persistentVolumeClaim:
+            claimName: shared-pvc
+```
+
+Force restart grafana container after to re-create.


### PR DESCRIPTION
This pull request introduces updates to the Kubernetes deployment configuration and documentation. Key changes include adjustments to the deployment manifest for port and security settings, as well as the addition of troubleshooting steps for Grafana database issues.

### Updates to Kubernetes deployment manifest:
* Updated `livenessProbe` and `readinessProbe` ports from `80` to `8080` in `deploy/aks-deployment.yml`.
* Added `securityContext` to specify `runAsUser` and `runAsGroup` as `472` for enhanced security in `deploy/aks-deployment.yml`.
* Changed the `targetPort` in the `ports` section from `80` to `8080` in `deploy/aks-deployment.yml`.

### Documentation enhancements:
* Added a new section in `deploy/kubernetes.md` to provide troubleshooting steps for resolving the Grafana "database is locked" error. This includes a sample Kubernetes Job to unlock the database.
* Minor formatting improvements in `deploy/kubernetes.md`, including the addition of blank lines for better readability. [[1]](diffhunk://#diff-56ce224c0e2f215a6cecd25ec7eee86cfe432d798f5d7f0e7a9c557ed93fb6d4R23-R27) [[2]](diffhunk://#diff-56ce224c0e2f215a6cecd25ec7eee86cfe432d798f5d7f0e7a9c557ed93fb6d4R47)