### PR TITLE
fix: skip seat when assignee is null

### DIFF
--- a/src/cpuad-updater/main.py
+++ b/src/cpuad-updater/main.py
@@ -486,6 +486,8 @@ class GitHubOrganizationManager:
             if not seats:
                 break
             for seat in seats:
+                if not seat.get("assignee"):
+                    continue
                 # assignee sub dict
                 seat["assignee_login"] = seat.get("assignee", {}).get("login")
                 # if organization_slug is CopilotNext, then assignee_login


### PR DESCRIPTION
Fixes a bug when a seat assignee field exists but is `null`. I do not know how to reproduce, but this is expected by the [`/orgs/{org}/copilot/billing/seats` response schema](https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#list-all-copilot-seat-assignments-for-an-organization)

> Example of response
```json
{
    "total_seats": 0,
    "seats": [
        {
            "created_at": "...",
            "assignee": null,
            "pending_cancellation_date": "...",
            "plan_type": "business",
            "updated_at": "...",
            "last_activity_at": null,
            "last_activity_editor": null
        }
    ]
}
```
